### PR TITLE
Fix datFile path in face_matching

### DIFF
--- a/detection/face_matching.py
+++ b/detection/face_matching.py
@@ -2,12 +2,13 @@ import cv2
 import dlib
 import numpy as np
 from deepface import DeepFace
+import os
 
 # import tensorflow as tf
 from scipy.spatial.distance import cosine
 
 # Path to the shape predictor file
-datFile = r"detection\shape_predictor_68_face_landmarks.dat"
+datFile = os.path.join(os.path.dirname(__file__), "shape_predictor_68_face_landmarks.dat")
 
 # Load the cascade
 face_cascade = cv2.CascadeClassifier(


### PR DESCRIPTION
## Summary
- use `os.path.join` to set path to landmark predictor
- add missing `os` import

## Testing
- `python -m py_compile detection/face_matching.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a3f67a3c8321b5ecfc97d9047ab0