### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.10-slim
+
+# Install system dependencies for dlib and opencv
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        libgl1-mesa-glx \
+        libglib2.0-0 \
+        && rm -rf /var/lib/apt/lists/*
+
+# Set work directory
+WORKDIR /app
+
+# Copy requirements
+COPY requirements.txt ./
+
+# Install python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port for flask
+EXPOSE 5000
+
+# Set environment variables
+ENV FLASK_APP=app.py
+ENV PYTHONUNBUFFERED=1
+
+# Run the application
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "app:app"]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ GateX offers the following features:
    ```
    Access the app at `http://127.0.0.1:5000`.
 
+### Docker
+
+You can also run GateX inside a Docker container. Build the image and start the
+service using the commands below:
+
+```bash
+docker build -t gatex .
+docker run -p 5000:5000 gatex
+```
+
+The container exposes port `5000`. Mount or edit `configs/database.yaml` if you
+need to supply different credentials or a service account path.
+
 ---
 
 ## Usage


### PR DESCRIPTION
## Summary
- add Dockerfile with gunicorn entrypoint
- document Docker build and run steps in README

## Testing
- `python -m py_compile app.py detection/face_matching.py utils/configuration.py`
- `python test/face-detection.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6852d77bc4808321a70125852a82d3a4