### PR TITLE
Enable browser-based webcam input

### DIFF
--- a/detection/face_matching.py
+++ b/detection/face_matching.py
@@ -213,3 +213,32 @@ def match_face(embedding, database):
         return match
     else:
         return None
+
+def identify_face(img, database):
+    """Detect and match the largest face in `img` against `database`.
+
+    Parameters
+    ----------
+    img : ndarray
+        BGR image to process.
+    database : dict
+        Mapping of names to embeddings.
+
+    Returns
+    -------
+    tuple
+        (name, probability) if a match is found, otherwise (None, 0.0).
+    """
+    faces = detect_faces(img)
+    for face in faces:
+        try:
+            aligned = align_face(img, face)
+            embedding = extract_features(aligned)[0]["embedding"]
+            match = match_face(embedding, database)
+            if match:
+                prob = 1 - cosine(embedding, database[match])
+                return match, float(prob)
+        except Exception:
+            continue
+    return None, 0.0
+

--- a/static/js/cam.js
+++ b/static/js/cam.js
@@ -1,0 +1,36 @@
+const video = document.getElementById('cam');
+
+if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+  navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
+    video.srcObject = stream;
+    video.play();
+
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+
+    setInterval(() => {
+      if (video.videoWidth === 0) return;
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob(blob => {
+        if (blob) {
+          fetch('/api/frame', {
+            method: 'POST',
+            headers: { 'Content-Type': 'image/jpeg' },
+            body: blob
+          })
+            .then(res => res.json())
+            .then(data => {
+              console.log('Recognition result:', data);
+            })
+            .catch(err => console.error('Send frame error', err));
+        }
+      }, 'image/jpeg');
+    }, 200);
+  }).catch(err => {
+    console.error('getUserMedia error:', err);
+  });
+} else {
+  console.error('getUserMedia not supported');
+}

--- a/template/index.html
+++ b/template/index.html
@@ -187,6 +187,7 @@
   </div>
 
 
+  <video id="cam" autoplay playsinline style="width: 100%; max-width: 500px;"></video>
   <!-- service section -->
 
   <section class="service_section layout_padding">
@@ -755,6 +756,7 @@
   </script>
   <!-- custom js -->
   <script type="text/javascript" src="js/custom.js"></script>
+  <script type="text/javascript" src="js/cam.js"></script>
   <!-- Google Map -->
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCh39n5U-4IoWpsVGUHWdqB6puEkhRLdmI&callback=myMap">
   </script>


### PR DESCRIPTION
## Summary
- add `static/js/cam.js` to capture webcam frames in the browser
- display webcam feed on the homepage and send frames via `/api/frame`
- introduce `identify_face` helper
- create `/api/frame` endpoint and enable CORS
- gracefully handle missing webcam in server routes

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852eddaada08321a93558ada7522e6e