### PR TITLE
Prepare Flask app for deployment on Render

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project, built with Python, Flask, OpenCV, and Firebase, streamlines gate m
 - [Screenshots](#screenshots)
 - [Installation](#installation)
 - [Usage](#usage)
+- [Deployment on Render](#deployment-on-render)
 - [Dependencies](#dependencies)
 - [Future Improvements](#future-improvements)
 - [Contribution](#contribution)
@@ -78,8 +79,8 @@ GateX offers the following features:
 3. **Configure Firebase & Cloudinary**:
    - Set up Firebase for the real-time database.
    - Sign up for [Cloudinary](https://cloudinary.com/) and obtain your **Cloud name**, **API key**, and **API secret**.
-   - Update `configs/database.yaml` with Firebase details and your Cloudinary credentials.
-   - Place your Firebase service account key (JSON) at the path specified in the YAML file.
+  - Copy `configs/database.example.yaml` to `configs/database.yaml` and update it with your Firebase and Cloudinary credentials.
+  - Place your Firebase service account key (JSON) at the path specified in the YAML file or use the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 
 4. **Download Face Landmark Model**:
    - Download: [shape_predictor_68_face_landmarks.dat.bz2](https://github.com/davisking/dlib-models/raw/master/shape_predictor_68_face_landmarks.dat.bz2)
@@ -102,6 +103,22 @@ GateX offers the following features:
 ### Admins
 - Approve or reject outpass requests.
 - Monitor current out status and view history.
+
+---
+
+## Deployment on Render
+
+1. Ensure all project dependencies are installed with `pip install -r requirements.txt`.
+2. Copy `configs/database.example.yaml` to `configs/database.yaml` and fill in your credentials.
+3. Upload `shape_predictor_68_face_landmarks.dat` to the `detection/` folder.
+4. Commit your code to a Git repository and connect it to [Render](https://render.com).
+5. On Render, create a new **Web Service** and set the following:
+   - **Build Command**: `pip install -r requirements.txt`
+   - **Start Command**: `gunicorn app:app`
+   - Add environment variables for `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`,
+     `CLOUDINARY_API_SECRET`, `GOOGLE_APPLICATION_CREDENTIALS`,
+     `FIREBASE_DATABASE_URL`, `TEACHER_PASSWORD_HASH`, and optionally `CONFIG_PATH`.
+6. Deploy the service. Render will automatically build and start the Flask app.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -29,22 +29,36 @@ from utils.configuration import load_yaml
 from jinja2 import Environment, select_autoescape
 
 
-config_file_path = load_yaml("configs/database.yaml")
+CONFIG_PATH = os.getenv("CONFIG_PATH", "configs/database.yaml")
+config_file_path = load_yaml(CONFIG_PATH)
 
-TEACHER_PASSWORD_HASH = config_file_path["teacher"]["password_hash"]
+TEACHER_PASSWORD_HASH = os.getenv(
+    "TEACHER_PASSWORD_HASH", config_file_path["teacher"]["password_hash"]
+)
 
-cred = credentials.Certificate(config_file_path["firebase"]["pathToServiceAccount"])
+cred_path = os.getenv(
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    config_file_path["firebase"]["pathToServiceAccount"],
+)
+database_url = os.getenv(
+    "FIREBASE_DATABASE_URL", config_file_path["firebase"]["databaseURL"]
+)
+cred = credentials.Certificate(cred_path)
 firebase_admin.initialize_app(
     cred,
     {
-        "databaseURL": config_file_path["firebase"]["databaseURL"],
+        "databaseURL": database_url,
     },
 )
 
 cloudinary.config(
-    cloud_name=config_file_path["cloudinary"]["cloud_name"],
-    api_key=config_file_path["cloudinary"]["api_key"],
-    api_secret=config_file_path["cloudinary"]["api_secret"],
+    cloud_name=os.getenv(
+        "CLOUDINARY_CLOUD_NAME", config_file_path["cloudinary"]["cloud_name"]
+    ),
+    api_key=os.getenv("CLOUDINARY_API_KEY", config_file_path["cloudinary"]["api_key"]),
+    api_secret=os.getenv(
+        "CLOUDINARY_API_SECRET", config_file_path["cloudinary"]["api_secret"]
+    ),
 )
 
 
@@ -777,4 +791,5 @@ def view_history():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port)

--- a/configs/database.example.yaml
+++ b/configs/database.example.yaml
@@ -1,0 +1,9 @@
+teacher:
+  password_hash: YOUR_HASH_HERE
+firebase:
+  databaseURL: YOUR_DATABASE_URL
+  pathToServiceAccount: path/to/serviceAccount.json
+cloudinary:
+  cloud_name: YOUR_CLOUD_NAME
+  api_key: YOUR_API_KEY
+  api_secret: YOUR_API_SECRET

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: gatex
+    runtime: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn app:app


### PR DESCRIPTION
## Summary
- add Procfile for gunicorn startup
- provide sample `database.example.yaml`
- configure `app.py` to read secrets from env vars
- add Render service definition
- document Render deployment steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852fc4f342c832185df32c23fae01f0