### PR TITLE
Fix DeepFace model loading and disable Eventlet

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ app.jinja_env = Environment(
 )
 app.jinja_env.globals.update(url_for=url_for)
 app.secret_key = "123456"
-socketio = SocketIO(app, cors_allowed_origins="*")
+socketio = SocketIO(app, async_mode="threading", cors_allowed_origins="*")
 current_frame = None
 
 UPLOAD_FOLDER = "static/images"


### PR DESCRIPTION
## Summary
- build a single Facenet model once at import time
- guard TensorFlow calls with a threading lock
- switch Flask‑SocketIO to normal threading mode

## Testing
- `python -m py_compile detection/face_matching.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6853ae45df58832197a2c61aa7f21681