### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+*.git*
+*.md
+venv/
+myenv/
+examples/
+*.exe
+*.dat
+*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies first for caching
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY . .
+
+# Expose port used by the Flask app
+EXPOSE 5000
+
+# Run the application
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project, built with Python, Flask, OpenCV, and Firebase, streamlines gate m
 - [Features](#features)
 - [Screenshots](#screenshots)
 - [Installation](#installation)
+- [Docker](#docker)
 - [Usage](#usage)
 - [Dependencies](#dependencies)
 - [Future Improvements](#future-improvements)
@@ -111,6 +112,14 @@ GateX offers the following features:
 
 ---
 
+## Docker
+
+To build and run GateX using Docker:
+```bash
+docker build -t gatex .
+docker run -p 5000:5000 gatex
+```
+
 ## Usage
 
 ### Students
@@ -141,7 +150,7 @@ Install all dependencies using:
 
 ```bash
 pip install -r requirements.txt
-```
+   ```
 
 ---
 


### PR DESCRIPTION
## Summary
- add Dockerfile
- add `.dockerignore`
- document Docker usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853c4ca4c808321b78dd251717a4159