### PR TITLE
Remove TLS from run block

### DIFF
--- a/app.py
+++ b/app.py
@@ -826,10 +826,9 @@ def view_history():
 
 
 if __name__ == "__main__":
-    # Run with HTTPS so the webcam can be accessed on non-localhost origins
     socketio.run(
         app,
         host="0.0.0.0",
-        port=int(os.getenv("PORT", 5000)),
-        ssl_context=("cert.pem", "key.pem"),
+        port=int(os.environ.get("PORT", 10000)),
+        debug=False
     )


### PR DESCRIPTION
## Summary
- remove HTTPS config from Flask-SocketIO startup
- bind to port from `PORT` env var

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6853f57c78c48321a67d74070c19b54d