### PR TITLE
Use gunicorn eventlet for Docker startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY . .
 # Expose port used by the Flask app
 EXPOSE 5000
 
-# Run the application
-CMD ["python", "app.py"]
+# Run the application with Gunicorn using the eventlet worker
+CMD ["gunicorn", "-k", "eventlet", "-w", "1", "-b", "0.0.0.0:5000", "app:app"]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ To build and run GateX using Docker:
 docker build -t gatex .
 docker run -p 5000:5000 gatex
 ```
+The container now starts the application with **Gunicorn** using the
+`eventlet` worker so WebSocket communication works out of the box.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- run the application in the container via `gunicorn` and the `eventlet` worker
- document the new Gunicorn startup command in the Docker section

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68540650ee408321abb16f0e994a67d5