### PR TITLE
Send video frame in POST requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -256,7 +256,16 @@ def uploaded_file(filename):
 @app.route("/markin", methods=["POST"])
 def markin():
     global filename, detection
-    frame = current_frame
+    frame = None
+    if request.is_json:
+        data = request.get_json(silent=True)
+        if data and 'image' in data:
+            try:
+                frame = b64_to_cv2(data['image'])
+            except Exception as e:
+                app.logger.error(f"Failed to decode image data: {e}")
+    if frame is None:
+        frame = current_frame
 
     if frame is not None:
         out_students_ref = db.reference("Out Students")
@@ -332,7 +341,16 @@ def markin():
 @app.route("/markout", methods=["POST"])
 def markout():
     global filename, detection
-    frame = current_frame
+    frame = None
+    if request.is_json:
+        data = request.get_json(silent=True)
+        if data and 'image' in data:
+            try:
+                frame = b64_to_cv2(data['image'])
+            except Exception as e:
+                app.logger.error(f"Failed to decode image data: {e}")
+    if frame is None:
+        frame = current_frame
 
     if frame is not None:
         ref = db.reference("Students")
@@ -493,7 +511,16 @@ def markout():
 @app.route("/capture", methods=["POST"])
 def capture():
     global filename
-    frame = current_frame
+    frame = None
+    if request.is_json:
+        data = request.get_json(silent=True)
+        if data and 'image' in data:
+            try:
+                frame = b64_to_cv2(data['image'])
+            except Exception as e:
+                app.logger.error(f"Failed to decode image data: {e}")
+    if frame is None:
+        frame = current_frame
     if frame is not None:
 
         ref = db.reference("Students")

--- a/template/mark_in.html
+++ b/template/mark_in.html
@@ -162,21 +162,28 @@
 
     <script>
         document.getElementById('capture-button').addEventListener('click', function () {
-            var xhr = new XMLHttpRequest();
-            xhr.open('POST', '{{ url_for("markin") }}', true);
-            xhr.onload = function () {
-                var response = JSON.parse(xhr.responseText);
-                if (xhr.status === 200) {
-                    alert(response.message);
+            const video = document.getElementById('video');
+            const canvas = document.createElement('canvas');
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            const dataURL = canvas.toDataURL('image/jpeg', 0.7);
+
+            fetch('{{ url_for("markin") }}', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ image: dataURL })
+            }).then(response => response.json()).then(data => {
+                if (data.status === 'success') {
+                    alert(data.message);
                     window.location.href = '{{ url_for("home") }}';
                 } else {
-                    alert(response.message);
+                    alert(data.message);
                 }
-            };
-            xhr.onerror = function () {
-                alert("An error occurred while processing the request.");
-            };
-            xhr.send();
+            }).catch(() => {
+                alert('An error occurred while processing the request.');
+            });
         });
     </script>
 <script type="module">

--- a/template/mark_out.html
+++ b/template/mark_out.html
@@ -176,21 +176,28 @@
 
     <script>
         document.getElementById('capture-button').addEventListener('click', function () {
-            var xhr = new XMLHttpRequest();
-            xhr.open('POST', '{{ url_for("markout") }}', true);  // Corrected url_for usage
-            xhr.onload = function () {
-                if (xhr.status === 200) {
-                    alert('Marked out successfully! Redirecting to home...');
-                    window.location.href = '{{ url_for("home") }}';  // Corrected url_for usage
+            const video = document.getElementById('video');
+            const canvas = document.createElement('canvas');
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            const dataURL = canvas.toDataURL('image/jpeg', 0.7);
+
+            fetch('{{ url_for("markout") }}', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ image: dataURL })
+            }).then(resp => resp.json()).then(data => {
+                if (data.status === 'success') {
+                    alert(data.message + ' Redirecting to home...');
+                    window.location.href = '{{ url_for("home") }}';
                 } else {
-                    xhr.responseText && JSON.parse(xhr.responseText).message &&
-                        alert(JSON.parse(xhr.responseText).message);
+                    alert(data.message);
                 }
-            };
-            xhr.onerror = function () {
+            }).catch(() => {
                 alert('An error occurred while processing your request.');
-            };
-            xhr.send();
+            });
         });
     </script>
     

--- a/template/register.html
+++ b/template/register.html
@@ -159,14 +159,23 @@
         const addInfoUrl = "{{ url_for('add_info') }}";
     
         document.getElementById('capture-button').addEventListener('click', function() {
-            var xhr = new XMLHttpRequest();
-            xhr.open('POST', captureUrl, true); // Use the JavaScript variable
-            xhr.onload = function() {
-                if (xhr.status === 200) {
-                    window.location.href = addInfoUrl; // Use the JavaScript variable
+            const video = document.getElementById('video');
+            const canvas = document.createElement('canvas');
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            const dataURL = canvas.toDataURL('image/jpeg', 0.7);
+
+            fetch(captureUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ image: dataURL })
+            }).then(response => {
+                if (response.status === 200) {
+                    window.location.href = addInfoUrl;
                 }
-            };
-            xhr.send();
+            });
         });
     </script>
     


### PR DESCRIPTION
## Summary
- include captured webcam frame in POST request for mark-in
- do the same for mark-out and capture for registration
- accept base64 image data in server routes instead of relying on shared global

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685423cafd648321a097906434047fc6