### PR TITLE
Fix Firebase credential parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ SECRET_KEY=change-me
 TEACHER_PASSWORD_HASH=
 
 # Firebase configuration
-# Place the full Firebase service account JSON here
+# Place the full Firebase service account JSON here. If the private key contains
+# newlines, escape them as \n or use actual newlines.
 FIREBASE_CREDENTIALS_JSON=
 FIREBASE_DB_URL=
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ GateX offers the following features:
    - Sign up for [Cloudinary](https://cloudinary.com/) and obtain your **Cloud name**, **API key**, and **API secret**.
   - Copy `.env.example` to `.env` and populate the values for `FIREBASE_CREDENTIALS_JSON`, `FIREBASE_DB_URL`, and the Cloudinary variables.
   - The value of `FIREBASE_CREDENTIALS_JSON` should be the entire Firebase service account JSON and must **not** be committed to version control.
+  - If the `private_key` contains newlines, represent them as `\n` in the `.env` file.
 
 4. **Download Face Landmark Model**:
    - Download: [shape_predictor_68_face_landmarks.dat.bz2](https://github.com/davisking/dlib-models/raw/master/shape_predictor_68_face_landmarks.dat.bz2)

--- a/app.py
+++ b/app.py
@@ -45,6 +45,9 @@ cred_json = os.environ.get(
     config_file_path["firebase"].get("serviceAccountJson"),
 )
 cred_info = json.loads(cred_json or "{}")
+# Support service account JSON with escaped newlines in the private key
+if "private_key" in cred_info:
+    cred_info["private_key"] = cred_info["private_key"].replace("\\n", "\n")
 cred = credentials.Certificate(cred_info)
 firebase_admin.initialize_app(
     cred,

--- a/test/face-detection.py
+++ b/test/face-detection.py
@@ -49,6 +49,8 @@ def match_with_database(img, database):
 
 cred_json = os.environ["FIREBASE_CREDENTIALS_JSON"]
 cred_info = json.loads(cred_json)
+if "private_key" in cred_info:
+    cred_info["private_key"] = cred_info["private_key"].replace("\\n", "\n")
 cred = credentials.Certificate(cred_info)
 firebase_admin.initialize_app(
     cred,


### PR DESCRIPTION
## Summary
- allow Firebase private key to be loaded with escaped newlines
- update instructions for using FIREBASE_CREDENTIALS_JSON

## Testing
- `python -m py_compile app.py test/face-detection.py`

------
https://chatgpt.com/codex/tasks/task_e_68547e62d25483219f24cfb83951dd6a