### PR TITLE
Fix loading overlay display

### DIFF
--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -2171,4 +2171,4 @@ select {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
-.loading-overlay{position:fixed;inset:0;display:flex;justify-content:center;align-items:center;background-color:rgba(0,0,0,.5);z-index:50}.spinner{width:2rem;height:2rem;border-width:4px;border-style:solid;border-color:#0ea5e9;border-top-color:transparent;border-radius:9999px;animation:spin 1s linear infinite}@keyframes spin{to{transform:rotate(1turn)}}
+.loading-overlay{position:fixed;inset:0;display:flex;justify-content:center;align-items:center;background-color:rgba(0,0,0,.5);z-index:50}.loading-overlay.hidden{display:none}.spinner{width:2rem;height:2rem;border-width:4px;border-style:solid;border-color:#0ea5e9;border-top-color:transparent;border-radius:9999px;animation:spin 1s linear infinite}@keyframes spin{to{transform:rotate(1turn)}}

--- a/static/tailwind-src/input.css
+++ b/static/tailwind-src/input.css
@@ -65,6 +65,11 @@
   .loading-overlay {
     @apply fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50;
   }
+
+  /* Ensure the overlay is hidden when the `hidden` class is applied */
+  .loading-overlay.hidden {
+    @apply hidden;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- ensure the loading overlay can be hidden via the `hidden` class

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685597e099d483218046dc0ec093d345