### PR TITLE
Implement live status feed

### DIFF
--- a/app.py
+++ b/app.py
@@ -325,6 +325,17 @@ def markin():
                     history_ref.child(latest_entry_key).update({"time_in": str(datetime.now())})
                     print(f"Updated history for {student_name} with time_in.")
 
+                # Notify clients about the status change
+                socketio.emit(
+                    "status_update",
+                    {
+                        "name": student_name,
+                        "status": "in",
+                        "time": str(datetime.now()),
+                    },
+                    broadcast=True,
+                )
+
                 return {
                     "status": "success",
                     "message": f"{student_name} has been marked in successfully!",
@@ -493,6 +504,17 @@ def markout():
                     "time_out": str(datetime.now()),
                     "time_in": None,  # Will update this when marking in
                 }
+            )
+
+            # Notify clients about the status change
+            socketio.emit(
+                "status_update",
+                {
+                    "name": student_name,
+                    "status": "out",
+                    "time": str(datetime.now()),
+                },
+                broadcast=True,
             )
 
             print("Successfully added student to 'Out Students' and 'History'.")

--- a/template/home.html
+++ b/template/home.html
@@ -12,6 +12,12 @@
     </div>
   </div>
 
+  <!-- Real-time Status Updates -->
+  <section class="container mx-auto px-4 py-4">
+    <h2 class="text-2xl font-semibold text-surface-800 dark:text-surface-100 mb-4">Recent Activity</h2>
+    <ul id="status-feed" class="space-y-2"></ul>
+  </section>
+
   <!-- Services Section -->
   <section class="container mx-auto px-4 py-8">
     <div class="text-center mb-12">
@@ -96,4 +102,21 @@
       <h3 class="text-center text-xl font-semibold mb-6">Developed by Tavish Chawla</h3>
     </div>
   </footer>
+
+{% block scripts %}
+  <script type="module">
+    import { io } from 'https://cdn.socket.io/4.7.5/socket.io.esm.min.js';
+    const socket = io();
+    const feed = document.getElementById('status-feed');
+    socket.on('status_update', data => {
+      const li = document.createElement('li');
+      li.textContent = `${data.time}: ${data.name} marked ${data.status}`;
+      feed.prepend(li);
+      if (feed.children.length > 5) {
+        feed.removeChild(feed.lastChild);
+      }
+    });
+  </script>
+{% endblock %}
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- broadcast mark in/out events with Socket.IO
- show recent status updates on the dashboard

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68563a5a39448321bde90b26f78a74c7