### PR TITLE
Update navbar links based on logged in user

### DIFF
--- a/template/base.html
+++ b/template/base.html
@@ -42,8 +42,19 @@
                     </span>
                 </a>
                 <nav class="hidden md:flex space-x-6">
-                    <a href="{{ url_for('mark_in') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Mark Entry</a>
-                    <a href="{{ url_for('register') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Register</a>
+                    {% if session.get('user_role') %}
+                        {% if session.get('user_role') == 'student' %}
+                            <a href="{{ url_for('student_dashboard', roll_number=session.get('roll_number')) }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Home</a>
+                        {% else %}
+                            <a href="{{ url_for('home') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Home</a>
+                            <a href="{{ url_for('mark_in') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Mark Entry</a>
+                            <a href="{{ url_for('register') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Register</a>
+                        {% endif %}
+                        <a href="{{ url_for('logout') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Logout</a>
+                    {% else %}
+                        <a href="{{ url_for('mark_in') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Mark Entry</a>
+                        <a href="{{ url_for('register') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Register</a>
+                    {% endif %}
                 </nav>
             </div>
         </header>


### PR DESCRIPTION
## Summary
- show Logout in navbar when any user is logged in
- show Home link that directs students to their dashboard and admins to the admin home
- keep original Mark Entry and Register links for admins or logged out users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857aabbffd08321bbb136237a183760