### PR TITLE
Remove Mark Entry/Register from navbar

### DIFF
--- a/template/base.html
+++ b/template/base.html
@@ -47,13 +47,8 @@
                             <a href="{{ url_for('student_dashboard', roll_number=session.get('roll_number')) }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Home</a>
                         {% else %}
                             <a href="{{ url_for('home') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Home</a>
-                            <a href="{{ url_for('mark_in') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Mark Entry</a>
-                            <a href="{{ url_for('register') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Register</a>
                         {% endif %}
                         <a href="{{ url_for('logout') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Logout</a>
-                    {% else %}
-                        <a href="{{ url_for('mark_in') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Mark Entry</a>
-                        <a href="{{ url_for('register') }}" class="text-surface-600 hover:text-primary-500 dark:text-surface-300 dark:hover:text-primary-400 transition-colors">Register</a>
                     {% endif %}
                 </nav>
             </div>


### PR DESCRIPTION
## Summary
- remove `Mark Entry` and `Register` links from `base.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857abb3f91883218bb07e4961c81a27