### PR TITLE
Format dates as DD-MM-YYYY

### DIFF
--- a/template/admin_review.html
+++ b/template/admin_review.html
@@ -27,9 +27,9 @@
                 <tr class="hover:bg-surface-50 dark:hover:bg-surface-750 transition-colors">
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.name }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.rollNumber }}</td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.outgoing_date }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.outgoing_date | format_ddmmyyyy }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.outgoing_time }}</td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.ingoing_date }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.ingoing_date | format_ddmmyyyy }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.ingoing_time }}</td>
                     <td class="px-6 py-4 text-sm text-surface-700 dark:text-surface-300">{{ request.reason }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm">

--- a/template/student_dashboard.html
+++ b/template/student_dashboard.html
@@ -86,9 +86,9 @@
                             {% for request in requests %}
                             <tr class="hover:bg-surface-50 dark:hover:bg-surface-750">
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.reason }}</td>
-                                <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.outgoing_date }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.outgoing_date | format_ddmmyyyy }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.outgoing_time }}</td>
-                                <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.ingoing_date }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.ingoing_date | format_ddmmyyyy }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-surface-700 dark:text-surface-300">{{ request.ingoing_time }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm">
                                     <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full 


### PR DESCRIPTION
## Summary
- add Jinja filter to render dates as `DD-MM-YYYY`
- store and display dates in the new format
- update timestamps when referencing static assets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ab30ceec83218fb5630d8846c198