### PR TITLE
Add login role selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -194,9 +194,19 @@ def match_with_database(img, database):
 
 
 @app.route("/")
+def choose_role():
+    """Display page to select teacher or student login."""
+    return render_template("login_choice.html", now=datetime.now())
+
+
+@app.route("/login")
 def login():
+    role = request.args.get("role", "student")
     return render_template(
-        "student_login.html", get_flashed_messages=get_flashed_messages,now=datetime.now()
+        "student_login.html",
+        get_flashed_messages=get_flashed_messages,
+        now=datetime.now(),
+        role=role,
     )
 
 @app.route("/logout")
@@ -235,7 +245,10 @@ def teacher_login():
             flash("Incorrect credentials")
 
     return render_template(
-        "student_login.html", get_flashed_messages=get_flashed_messages, now=datetime.now()
+        "student_login.html",
+        get_flashed_messages=get_flashed_messages,
+        now=datetime.now(),
+        role="teacher",
     )
 
 
@@ -763,7 +776,10 @@ def student_login():
         flash("Student ID not found")
 
     return render_template(
-        "student_login.html", get_flashed_messages=get_flashed_messages,now=datetime.now()
+        "student_login.html",
+        get_flashed_messages=get_flashed_messages,
+        now=datetime.now(),
+        role="student",
     )
 
 

--- a/template/login_choice.html
+++ b/template/login_choice.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block title %}Select Login{% endblock %}
+
+{% block content %}
+<div class="relative min-h-screen flex items-center justify-center px-4 py-12" style="background-image: url({{ url_for('static', filename='images/slider-img.png') }}); background-size: cover; background-position: center;">
+    <div class="absolute inset-0 bg-black bg-opacity-50"></div>
+    <div class="relative z-10 w-full max-w-md text-center space-y-6">
+        <h1 class="text-3xl font-bold text-white">Login As</h1>
+        <a href="{{ url_for('login') }}?role=student" class="block w-full px-6 py-3 rounded-lg bg-green-500 bg-opacity-80 hover:bg-opacity-90 text-white backdrop-blur-sm">Student</a>
+        <a href="{{ url_for('login') }}?role=teacher" class="block w-full px-6 py-3 rounded-lg bg-green-500 bg-opacity-80 hover:bg-opacity-90 text-white backdrop-blur-sm">Teacher</a>
+    </div>
+</div>
+{% endblock %}

--- a/template/student_login.html
+++ b/template/student_login.html
@@ -92,5 +92,12 @@
         document.getElementById('student-form').classList.toggle('hidden', type !== 'student');
         document.getElementById('teacher-form').classList.toggle('hidden', type !== 'teacher');
     }
+
+    // Show the requested form on page load if role is provided
+    {% if role %}
+    document.addEventListener('DOMContentLoaded', function() {
+        showForm('{{ role }}');
+    });
+    {% endif %}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a new page to choose teacher or student login
- show chosen form in the login page
- update routes for login choice

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858dc36fce08321a39c036061e03d51