### PR TITLE
Fix teacher login with default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ GateX offers the following features:
   - Copy `.env.example` to `.env` and populate the values for `FIREBASE_CREDENTIALS_JSON`, `FIREBASE_DB_URL`, and the Cloudinary variables.
   - The value of `FIREBASE_CREDENTIALS_JSON` should be the entire Firebase service account JSON and must **not** be committed to version control.
   - If the `private_key` contains newlines, represent them as `\n` in the `.env` file.
+  - (Optional) Set `TEACHER_PASSWORD_HASH` to override the default teacher
+    password.  The application falls back to `admin123` if this variable is not
+    provided.
 
 4. **Download Face Landmark Model**:
    - Download: [shape_predictor_68_face_landmarks.dat.bz2](https://github.com/davisking/dlib-models/raw/master/shape_predictor_68_face_landmarks.dat.bz2)

--- a/app.py
+++ b/app.py
@@ -38,6 +38,14 @@ from functools import wraps
 load_env()
 
 TEACHER_PASSWORD_HASH = os.environ.get("TEACHER_PASSWORD_HASH")
+if not TEACHER_PASSWORD_HASH:
+    # Default fallback password for the teacher login.
+    # This mirrors the credentials shown on the login page
+    # (username "admin", password "admin123") so the app can
+    # run without custom configuration.  Users can override
+    # this by setting the TEACHER_PASSWORD_HASH environment
+    # variable to the hashed value of their desired password.
+    TEACHER_PASSWORD_HASH = generate_password_hash("admin123")
 
 cred_json = os.environ.get("FIREBASE_CREDENTIALS_JSON")
 cred_info = json.loads(cred_json or "{}")


### PR DESCRIPTION
## Summary
- set a fallback hashed password if `TEACHER_PASSWORD_HASH` is not defined
- document optional `TEACHER_PASSWORD_HASH` variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858dfd22ba083219f113f965f91d37d