### PR TITLE
Fix session secret key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ GateX offers the following features:
   - (Optional) Set `TEACHER_PASSWORD_HASH` to override the default teacher
     password.  The application falls back to `admin123` if this variable is not
     provided.
+  - **Required:** set `SECRET_KEY` to a fixed value for signing Flask session
+    cookies. Use the same value in your local `.env` file and in the Hugging Face
+    **Variables** tab so logins remain valid across workers.
 
 4. **Download Face Landmark Model**:
    - Download: [shape_predictor_68_face_landmarks.dat.bz2](https://github.com/davisking/dlib-models/raw/master/shape_predictor_68_face_landmarks.dat.bz2)

--- a/app.py
+++ b/app.py
@@ -92,7 +92,9 @@ def format_ddmmyyyy(value):
 
 
 app.jinja_env.filters["format_ddmmyyyy"] = format_ddmmyyyy
-app.secret_key = os.environ.get("SECRET_KEY", "123456")
+app.secret_key = os.environ["SECRET_KEY"]
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_SECURE"] = True
 socketio = SocketIO(app, async_mode="threading", cors_allowed_origins="*")
 current_frame = None
 


### PR DESCRIPTION
## Summary
- use environment SECRET_KEY for Flask sessions
- document SECRET_KEY usage in README
- require secure, Lax session cookies

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858e51e83a8832196f6f42da5f1a5be