### PR TITLE
Enforce role-based access for sensitive routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -303,6 +303,7 @@ def uploaded_file(filename):
 
 
 @app.route("/markin", methods=["POST"])
+@login_required(role="teacher")
 def markin():
     global filename, detection
     frame = None
@@ -388,6 +389,7 @@ def markin():
 
 
 @app.route("/markout", methods=["POST"])
+@login_required(role="teacher")
 def markout():
     global filename, detection
     frame = None
@@ -799,16 +801,19 @@ def student_dashboard(roll_number):
 
 
 @app.route("/mark_out")
+@login_required(role="teacher")
 def mark_out():
     return render_template("mark_out.html",now=datetime.now())
 
 
 @app.route("/mark_in")
+@login_required(role="teacher")
 def mark_in():
     return render_template("mark_in.html",now=datetime.now())
 
 
 @app.route("/view_out_students")
+@login_required(role="teacher")
 def view_out_students():
     try:
 
@@ -900,6 +905,7 @@ def register():
 
 
 @app.route("/view_history")
+@login_required(role="teacher")
 def view_history():
     history_ref = db.reference("History")
     history_data = history_ref.get()  # Fetch data from Firebase


### PR DESCRIPTION
## Summary
- enforce teacher access for markin/markout APIs
- restrict mark_in/mark_out, view_out_students and view_history to teachers

## Testing
- `python -m py_compile app.py`
- `flake8 app.py`

------
https://chatgpt.com/codex/tasks/task_e_685ea66f5f3c8321bbd2fd80f4641072