### PR TITLE
Add global flash message rendering

### DIFF
--- a/template/base.html
+++ b/template/base.html
@@ -58,6 +58,20 @@
             </div>
         </header>
 
+        <!-- Flash messages -->
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                <div class="container mx-auto px-4 mt-4 space-y-2">
+                    {% for category, message in messages %}
+                        <div class="p-4 rounded-lg shadow-md text-sm
+                            {% if category == 'success' %}bg-green-100 text-green-800{% elif category == 'error' %}bg-red-100 text-red-800{% else %}bg-blue-100 text-blue-800{% endif %}">
+                            {{ message }}
+                        </div>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        {% endwith %}
+
         <!-- Main content block -->
         <main class="flex-grow container mx-auto px-4 py-8">
             {% block content %}{% endblock %}

--- a/template/student_login.html
+++ b/template/student_login.html
@@ -43,13 +43,6 @@
                     </button>
                 </form>
                 
-                {% with messages = get_flashed_messages() %}
-                    {% if messages %}
-                        <div class="mt-4 text-center text-red-500 dark:text-red-400">
-                            {{ messages[0] }}
-                        </div>
-                    {% endif %}
-                {% endwith %}
             </div>
         </div>
 
@@ -75,13 +68,6 @@
                     </p>
                 </form>
                 
-                {% with messages = get_flashed_messages() %}
-                    {% if messages %}
-                        <div class="mt-4 text-center text-red-500 dark:text-red-400">
-                            {{ messages[0] }}
-                        </div>
-                    {% endif %}
-                {% endwith %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a flash message section to the layout so messages show on all pages
- remove inline flash logic from the login page

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685eaba750dc8321a124a7b7c8d50099