### PR TITLE
Prevent access to login page if user is logged in

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,8 +195,15 @@ def login_required(role=None):
 
 @app.route("/")
 def login():
+    user_type = session.get("user_type")
+    if user_type == "teacher":
+        return redirect(url_for("home"))
+    if user_type == "student":
+        roll = session.get("student_id")
+        if roll:
+            return redirect(url_for("student_dashboard", roll_number=roll))
     return render_template(
-        "student_login.html", get_flashed_messages=get_flashed_messages,now=datetime.now()
+        "student_login.html", get_flashed_messages=get_flashed_messages, now=datetime.now()
     )
 
 @app.route("/logout")
@@ -233,6 +240,13 @@ def add_info():
 
 @app.route("/teacher_login", methods=["GET", "POST"])
 def teacher_login():
+    user_type = session.get("user_type")
+    if user_type == "teacher":
+        return redirect(url_for("home"))
+    if user_type == "student":
+        roll = session.get("student_id")
+        if roll:
+            return redirect(url_for("student_dashboard", roll_number=roll))
     if request.method == "POST":
         teacher_name = request.form.get("teacher_name")
         password = request.form.get("password")


### PR DESCRIPTION
## Summary
- redirect to dashboard/home when an authenticated user visits `/` or `/teacher_login`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb225cf908321a10d78c1adb229aa