### PR TITLE
Add demo student login credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ and `PORT` values.
 ### Students
 - Submit outpass requests.
 - Mark out/in using facial recognition.
+- For demonstration, log in to the student portal with ID `IIT2023001` and
+  password `12345678`.
 
 ### Admins
 - Approve or reject outpass requests.

--- a/template/student_login.html
+++ b/template/student_login.html
@@ -41,6 +41,9 @@
                     <button type="submit" class="btn-primary w-full bg-primary-500 hover:bg-primary-600">
                         Login
                     </button>
+                    <p class="mt-2 text-center text-surface-600 dark:text-surface-400 text-sm">
+                        Demo login: ID <code>IIT2023001</code>, password <code>12345678</code>.
+                    </p>
                 </form>
                 
             </div>


### PR DESCRIPTION
## Summary
- add demo student account information in README
- show demo login details on the student login page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685eb29cddd88321bcfd51f689b5472e