### PR TITLE
Add cache-control headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,6 +78,15 @@ app.secret_key = os.environ.get("SECRET_KEY", "123456")
 socketio = SocketIO(app, async_mode="threading", cors_allowed_origins="*")
 current_frame = None
 
+
+@app.after_request
+def add_cache_control_headers(response):
+    """Prevent caching to stop back/forward navigation after logout."""
+    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
+
 UPLOAD_FOLDER = "static/images"
 app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
 


### PR DESCRIPTION
## Summary
- prevent cached pages from being accessible with the back button

## Testing
- `pytest -q`
- `npm test --silent` *(fails: no test specified)*
- `python integrity/sign_file.py app.py` *(fails: ModuleNotFoundError: No module named 'cryptography')*


------
https://chatgpt.com/codex/tasks/task_e_685eb498fad48321a3bc3cb8c873add9