### PR TITLE
Add toast notification system

### DIFF
--- a/static/js/toast.js
+++ b/static/js/toast.js
@@ -1,0 +1,37 @@
+(function(){
+  function getStyle(category){
+    switch(category){
+      case 'success':
+        return 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100 ring-green-300 dark:ring-green-600';
+      case 'error':
+        return 'bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100 ring-red-300 dark:ring-red-600';
+      default:
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100 ring-blue-300 dark:ring-blue-600';
+    }
+  }
+
+  window.showToast = function(message, category='message'){
+    const container = document.getElementById('toast-container');
+    if(!container) return;
+
+    const toast = document.createElement('div');
+    toast.className = 'toast pointer-events-auto max-w-xs w-full ring-1 rounded-md shadow-soft dark:shadow-soft-dark transform transition-all duration-500 ease-in-out translate-x-full opacity-0 ' + getStyle(category);
+    toast.innerHTML = '<div class="p-4 flex items-start"><div class="flex-1 text-sm">'+message+'</div><button class="ml-4 text-xl leading-none focus:outline-none" aria-label="Close">&times;</button></div>';
+
+    const btn = toast.querySelector('button');
+    btn.addEventListener('click', () => removeToast(toast));
+
+    container.appendChild(toast);
+
+    requestAnimationFrame(() => {
+      toast.classList.remove('translate-x-full','opacity-0');
+    });
+
+    setTimeout(() => removeToast(toast), 10000);
+  };
+
+  function removeToast(toast){
+    toast.classList.add('translate-x-full','opacity-0');
+    toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+  }
+})();

--- a/template/base.html
+++ b/template/base.html
@@ -19,6 +19,9 @@
     <link rel="icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
 </head>
 <body class="min-h-screen bg-surface-50 text-surface-900 dark:bg-surface-900 dark:text-surface-100 transition-colors duration-200">
+    <!-- Toast container -->
+    <div id="toast-container" class="fixed top-5 right-5 z-50 space-y-4"></div>
+
     <!-- Dark mode toggle button (fixed in corner) -->
     <button onclick="toggleDarkMode()" 
             class="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-surface-200 dark:bg-surface-700 shadow-lg  transition-all"
@@ -58,19 +61,11 @@
             </div>
         </header>
 
-        <!-- Flash messages -->
-        {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages %}
-                <div class="container mx-auto px-4 mt-4 space-y-2">
-                    {% for category, message in messages %}
-                        <div class="p-4 rounded-lg shadow-md text-sm
-                            {% if category == 'success' %}bg-green-100 text-green-800{% elif category == 'error' %}bg-red-100 text-red-800{% else %}bg-blue-100 text-blue-800{% endif %}">
-                            {{ message }}
-                        </div>
-                    {% endfor %}
-                </div>
-            {% endif %}
-        {% endwith %}
+        <!-- Placeholder for server-sent messages -->
+        {% set flashed = get_flashed_messages(with_categories=true) %}
+        <script>
+            window.__flashed_messages__ = {{ flashed|tojson }};
+        </script>
 
         <!-- Main content block -->
         <main class="flex-grow container mx-auto px-4 py-8">
@@ -109,6 +104,17 @@
 
         // Run initialization
         initDarkMode();
+    </script>
+
+    <script src="{{ url_for('static', filename='js/toast.js') }}"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            if (window.__flashed_messages__) {
+                window.__flashed_messages__.forEach(([category, message]) => {
+                    window.showToast(message, category);
+                });
+            }
+        });
     </script>
 
     <!-- Additional scripts block -->


### PR DESCRIPTION
## Summary
- add a global toast container in the base template
- surface Flask flashed messages through JS
- include a new `toast.js` helper to show and dismiss toasts
- automatically initialize toasts on page load

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`
- `npm install`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_685f98516ee883219d9d0d06313d814a