### PR TITLE
Fix view history layout with pagination

### DIFF
--- a/template/view_history.html
+++ b/template/view_history.html
@@ -3,9 +3,7 @@
 {% block title %}Student Movement History{% endblock %}
 
 {% block content %}
-<div class="flex flex-col min-h-screen">
-    <!-- Main Content -->
-    <main class="flex-grow container mx-auto px-4 py-6">
+<div class="flex flex-col min-h-screen container mx-auto px-4 py-6">
         <div class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
             <div>
                 <h1 class="text-2xl md:text-3xl font-bold text-surface-800 dark:text-surface-100">Student Movement History</h1>
@@ -38,8 +36,8 @@
 
         {% if history %}
         <!-- Timeline View -->
-        <div class="space-y-4">
-            {% for key, entry in history.items() %}
+        <div class="space-y-4 flex-grow">
+            {% for entry in history %}
             <div class="group relative p-4 bg-white dark:bg-surface-700 rounded-xl shadow-xs hover:shadow-sm transition-all border-l-4 {% if entry.time_in and not entry.time_out %}border-green-500{% elif entry.time_out and not entry.time_in %}border-red-500{% else %}border-surface-200 dark:border-surface-600{% endif %}">
                 <div class="flex items-start gap-4">
                     <!-- Student Avatar -->
@@ -114,23 +112,24 @@
             </div>
             {% endfor %}
         </div>
-        
-        <!-- Pagination -->
-        <div class="mt-8 flex justify-center">
+
+        {% if total_pages > 1 %}
+        <div class="mt-auto pt-6 flex justify-center">
             <nav class="flex items-center gap-1">
-                <button class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600">
+                {% set prev_page = current_page - 1 %}
+                <a href="{{ url_for('view_history', page=prev_page) }}" class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600 {% if current_page <= 1 %}pointer-events-none opacity-50{% endif %}">
                     <i class="fas fa-chevron-left"></i>
-                </button>
-                <button class="px-3 py-1 rounded-md bg-primary-500 text-white">1</button>
-                <button class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600">2</button>
-                <button class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600">3</button>
-                <span class="px-3 py-1 text-surface-500 dark:text-surface-400">...</span>
-                <button class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600">10</button>
-                <button class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600">
+                </a>
+                {% for p in range(1, total_pages + 1) %}
+                <a href="{{ url_for('view_history', page=p) }}" class="px-3 py-1 rounded-md {% if p == current_page %}bg-primary-500 text-white{% else %}bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600{% endif %}">{{ p }}</a>
+                {% endfor %}
+                {% set next_page = current_page + 1 %}
+                <a href="{{ url_for('view_history', page=next_page) }}" class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600 {% if current_page >= total_pages %}pointer-events-none opacity-50{% endif %}">
                     <i class="fas fa-chevron-right"></i>
-                </button>
+                </a>
             </nav>
         </div>
+        {% endif %}
         {% else %}
         <!-- Empty State -->
         <div class="flex flex-col items-center justify-center py-12 text-center">
@@ -146,7 +145,6 @@
             </button>
         </div>
         {% endif %}
-    </main>
 </div>
 
 <style>


### PR DESCRIPTION
## Summary
- implement basic pagination in `view_history` route
- sort and paginate history entries and expose page information
- update `view_history.html` layout with dynamic pagination component

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686137b90e58832187af2ba99a720f12