### PR TITLE
Implement view history search

### DIFF
--- a/app.py
+++ b/app.py
@@ -948,6 +948,7 @@ def view_history():
     # Date range filtering
     start_date_str = request.args.get("start_date")
     end_date_str = request.args.get("end_date")
+    search_query = request.args.get("search", "")
 
     try:
         start_date = (
@@ -990,6 +991,18 @@ def view_history():
     # Sort entries by checkout time (latest first)
     records.sort(key=lambda x: parse_dt(x.get("time_out") or x.get("time_in") or ""), reverse=True)
 
+    # Filter by search query
+    if search_query:
+        s = search_query.lower()
+        filtered = []
+        for r in records:
+            name = str(r.get("name", "")).lower()
+            roll = str(r.get("rollNumber", "")).lower()
+            phone = str(r.get("phone", "")).lower()
+            if s in name or s in roll or s in phone:
+                filtered.append(r)
+        records = filtered
+
     # Filter by date range if provided
     if start_date or end_date:
         filtered = []
@@ -1025,6 +1038,7 @@ def view_history():
         current_page=page,
         start_date=start_date_str,
         end_date=end_date_str,
+        search=search_query,
         now=datetime.now(),
     )
 

--- a/template/view_history.html
+++ b/template/view_history.html
@@ -24,8 +24,15 @@
                 
                 <!-- Search -->
                 <div class="relative">
-                    <input type="text" placeholder="Search students..." class="pl-10 pr-4 py-2 bg-surface-100 dark:bg-surface-700 rounded-lg text-surface-700 dark:text-surface-300 w-full md:w-64 focus:ring-2 focus:ring-primary-500 focus:border-transparent">
-                    <i class="fas fa-search absolute left-3 top-3 text-surface-400"></i>
+                    <form method="get" action="{{ url_for('view_history') }}" class="flex items-center">
+                        <input type="text" name="search" value="{{ search or '' }}" placeholder="Search students..." class="form-input pl-10 pr-4 h-10 w-full md:w-64" />
+                        <input type="hidden" name="start_date" value="{{ start_date or '' }}" />
+                        <input type="hidden" name="end_date" value="{{ end_date or '' }}" />
+                        <input type="hidden" name="page" value="1" />
+                        <button type="submit" class="absolute left-3 top-3 text-surface-400">
+                            <i class="fas fa-search"></i>
+                        </button>
+                    </form>
                 </div>
                 
                 <!-- Export -->
@@ -119,14 +126,14 @@
         <div class="mt-auto pt-6 flex justify-center">
             <nav class="flex items-center gap-1">
                 {% set prev_page = current_page - 1 %}
-                <a href="{{ url_for('view_history', page=prev_page, start_date=request.args.get('start_date'), end_date=request.args.get('end_date')) }}" class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600 {% if current_page <= 1 %}pointer-events-none opacity-50{% endif %}">
+                <a href="{{ url_for('view_history', page=prev_page, start_date=request.args.get('start_date'), end_date=request.args.get('end_date'), search=request.args.get('search')) }}" class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600 {% if current_page <= 1 %}pointer-events-none opacity-50{% endif %}">
                     <i class="fas fa-chevron-left"></i>
                 </a>
                 {% for p in range(1, total_pages + 1) %}
-                <a href="{{ url_for('view_history', page=p, start_date=request.args.get('start_date'), end_date=request.args.get('end_date')) }}" class="px-3 py-1 rounded-md {% if p == current_page %}bg-primary-500 text-white{% else %}bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600{% endif %}">{{ p }}</a>
+                <a href="{{ url_for('view_history', page=p, start_date=request.args.get('start_date'), end_date=request.args.get('end_date'), search=request.args.get('search')) }}" class="px-3 py-1 rounded-md {% if p == current_page %}bg-primary-500 text-white{% else %}bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600{% endif %}">{{ p }}</a>
                 {% endfor %}
                 {% set next_page = current_page + 1 %}
-                <a href="{{ url_for('view_history', page=next_page, start_date=request.args.get('start_date'), end_date=request.args.get('end_date')) }}" class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600 {% if current_page >= total_pages %}pointer-events-none opacity-50{% endif %}">
+                <a href="{{ url_for('view_history', page=next_page, start_date=request.args.get('start_date'), end_date=request.args.get('end_date'), search=request.args.get('search')) }}" class="px-3 py-1 rounded-md bg-surface-100 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-600 {% if current_page >= total_pages %}pointer-events-none opacity-50{% endif %}">
                     <i class="fas fa-chevron-right"></i>
                 </a>
             </nav>


### PR DESCRIPTION
## Summary
- add search filter logic on the `/view_history` route
- expose search parameter to the history template
- update history template with search form and query-aware pagination

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68613d32d6ac83219b4018d3a96ca631