### PR TITLE
Add image upload recognition support

### DIFF
--- a/template/mark_in.html
+++ b/template/mark_in.html
@@ -39,7 +39,7 @@
                     <p class="text-surface-600 dark:text-surface-300 mb-4">
                         Can't use the camera? Upload an image instead
                     </p>
-                    <form action="{{ url_for('mark_in') }}" method="post" enctype="multipart/form-data" class="space-y-4">
+                    <form action="{{ url_for('markin') }}" method="post" enctype="multipart/form-data" class="space-y-4">
                         <div class="flex items-center justify-center w-full">
                             <label for="dropzone-file" class="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed border-surface-300 dark:border-surface-600 rounded-xl cursor-pointer hover:bg-surface-50 dark:hover:bg-surface-700/50 transition-colors duration-200">
                                 <div class="flex flex-col items-center justify-center pt-5 pb-6 px-4 text-center">

--- a/template/mark_out.html
+++ b/template/mark_out.html
@@ -39,7 +39,7 @@
                     <p class="text-surface-600 dark:text-surface-300 mb-4">
                         Can't use the camera? Upload an image instead
                     </p>
-                    <form action="{{ url_for('mark_out') }}" method="post" enctype="multipart/form-data" class="space-y-4">
+                    <form action="{{ url_for('markout') }}" method="post" enctype="multipart/form-data" class="space-y-4">
                         <div class="flex items-center justify-center w-full">
                             <label for="dropzone-file" class="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed border-surface-300 dark:border-surface-600 rounded-xl cursor-pointer hover:bg-surface-50 dark:hover:bg-surface-700/50 transition-colors duration-200">
                                 <div class="flex flex-col items-center justify-center pt-5 pb-6 px-4 text-center">


### PR DESCRIPTION
## Summary
- allow upload of image for mark in/out
- update mark in/out pages to submit to processing endpoints
- return flash messages for uploaded images

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862af4a73008321ac297f11d8be0fef