### PR TITLE
Implement auto capture delay

### DIFF
--- a/template/mark_in.html
+++ b/template/mark_in.html
@@ -331,6 +331,7 @@
     let autoCaptureEnabled = false;
     let autoCaptureInterval = null;
     let isProcessing = false;
+    let lastCaptureTime = 0; // track time of last capture for delay
 
     document.getElementById('auto-capture').addEventListener('change', function(e) {
         autoCaptureEnabled = e.target.checked;
@@ -374,6 +375,8 @@
     }
 
     function checkForFace() {
+        const now = Date.now();
+        if (now - lastCaptureTime < 5000) return; // enforce 5s gap
         const video = document.getElementById('video');
         const canvas = document.createElement('canvas');
         canvas.width = video.videoWidth;
@@ -428,6 +431,7 @@
         }
         
         isProcessing = true;
+        lastCaptureTime = Date.now();
         
         const modal = document.getElementById('processing-modal');
         const modalContent = modal.querySelector('.transform');
@@ -469,14 +473,16 @@
             setTimeout(() => modal.classList.add('hidden'), 300);
             
             if (data.status === 'success') {
-                showToast({ 
-                    message: data.message, 
+                showToast({
+                    message: data.message,
                     type: 'success',
                     duration: 3000
                 });
-                setTimeout(() => {
-                    window.location.href = '{{ url_for("home") }}';
-                }, 1500);
+                if (!autoCaptureEnabled) {
+                    setTimeout(() => {
+                        window.location.href = '{{ url_for("home") }}';
+                    }, 1500);
+                }
             } else {
                 showToast({ 
                     message: data.message, 

--- a/template/mark_out.html
+++ b/template/mark_out.html
@@ -330,6 +330,7 @@
     let autoCaptureEnabled = false;
     let autoCaptureInterval = null;
     let isProcessing = false;
+    let lastCaptureTime = 0;
 
     document.getElementById('auto-capture').addEventListener('change', function(e) {
         autoCaptureEnabled = e.target.checked;
@@ -373,6 +374,8 @@
     }
 
     function checkForFace() {
+        const now = Date.now();
+        if (now - lastCaptureTime < 5000) return;
         const video = document.getElementById('video');
         const canvas = document.createElement('canvas');
         canvas.width = video.videoWidth;
@@ -427,6 +430,7 @@
         }
         
         isProcessing = true;
+        lastCaptureTime = Date.now();
         
         const modal = document.getElementById('processing-modal');
         const modalContent = modal.querySelector('.transform');
@@ -468,14 +472,16 @@
             setTimeout(() => modal.classList.add('hidden'), 300);
             
             if (data.status === 'success') {
-                showToast({ 
-                    message: data.message, 
+                showToast({
+                    message: data.message,
                     type: 'success',
                     duration: 3000
                 });
-                setTimeout(() => {
-                    window.location.href = '{{ url_for("home") }}';
-                }, 1500);
+                if (!autoCaptureEnabled) {
+                    setTimeout(() => {
+                        window.location.href = '{{ url_for("home") }}';
+                    }, 1500);
+                }
             } else {
                 showToast({ 
                     message: data.message, 

--- a/template/register.html
+++ b/template/register.html
@@ -337,6 +337,7 @@
     let autoCaptureEnabled = false;
     let autoCaptureInterval = null;
     let isProcessing = false;
+    let lastCaptureTime = 0;
 
     document.getElementById('auto-capture').addEventListener('change', function(e) {
         autoCaptureEnabled = e.target.checked;
@@ -380,6 +381,8 @@
     }
 
     function checkForFace() {
+        const now = Date.now();
+        if (now - lastCaptureTime < 5000) return;
         const video = document.getElementById('video');
         const canvas = document.createElement('canvas');
         canvas.width = video.videoWidth;
@@ -434,6 +437,7 @@
         }
         
         isProcessing = true;
+        lastCaptureTime = Date.now();
         
         const modal = document.getElementById('processing-modal');
         const modalContent = modal.querySelector('.transform');
@@ -473,14 +477,16 @@
             setTimeout(() => modal.classList.add('hidden'), 300);
             
             if (response.status === 200) {
-                showToast({ 
-                    message: "Registration successful! Redirecting to add information...", 
+                showToast({
+                    message: "Registration successful! Redirecting to add information...",
                     type: 'success',
                     duration: 3000
                 });
-                setTimeout(() => {
-                    window.location.href = addInfoUrl;
-                }, 1500);
+                if (!autoCaptureEnabled) {
+                    setTimeout(() => {
+                        window.location.href = addInfoUrl;
+                    }, 1500);
+                }
             } else {
                 showToast({ 
                     message: "Registration failed. Please try again.", 


### PR DESCRIPTION
## Summary
- add `lastCaptureTime` to mark_in/out/register pages
- prevent successive captures for 5s when auto capture enabled
- skip redirect after successful capture when auto capture enabled

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build:css` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639ea590748321befee05779dfc980